### PR TITLE
👕 Set up `Standard JS` linter

### DIFF
--- a/lib/toggle-markdown-task.js
+++ b/lib/toggle-markdown-task.js
@@ -40,7 +40,7 @@ function toggleSelection (selection) {
 }
 
 function toggleTask (taskText) {
-  const regex = new RegExp(/([\-\*]\ )(\[[\ x]\])/)
+  const regex = new RegExp(/([-*] )(\[[ x]\])/)
 
   return taskText.replace(regex, (_, taskPrefix, taskStatus) => {
     return (taskStatus === '[ ]') ? `${taskPrefix}[x]` : `${taskPrefix}[ ]`

--- a/package.json
+++ b/package.json
@@ -20,5 +20,13 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "devDependencies": {
+    "standard": "*"
+  },
+  "standard": {
+    "globals": [
+      "atom"
+    ]
+  }
 }

--- a/spec/toggle-markdown-task-spec.js
+++ b/spec/toggle-markdown-task-spec.js
@@ -28,7 +28,7 @@ describe('toggling markdown task', () => {
       `)
       editor.setCursorBufferPosition([1, 0])
 
-      expectedTextAfterToggling = `\
+      const expectedTextAfterToggling = `\
         - [ ] A
         - [x] B
         - [ ] C
@@ -44,7 +44,7 @@ describe('toggling markdown task', () => {
       `)
       editor.setCursorBufferPosition([1, 0])
 
-      expectedTextAfterToggling = `\
+      const expectedTextAfterToggling = `\
         - [ ] A
         - [ ] B
         - [ ] C
@@ -78,7 +78,7 @@ describe('toggling markdown task', () => {
       `)
       editor.setSelectedBufferRange([[1, 1], [2, 1]])
 
-      expectedTextAfterToggling = `\
+      const expectedTextAfterToggling = `\
         - [ ] A
         - [x] B
         - [x] C
@@ -119,7 +119,7 @@ describe('toggling markdown task', () => {
       // Add cursor with selection range that includes tasks "C" and "D"
       editor.addSelectionForBufferRange([[2, 0], [3, 7]])
 
-      expectedTextAfterToggling = `\
+      const expectedTextAfterToggling = `\
         - [x] A
         - [ ] B
         - [x] C

--- a/spec/toggle-markdown-task-spec.js
+++ b/spec/toggle-markdown-task-spec.js
@@ -1,3 +1,5 @@
+/* global beforeEach, describe, expect, it, runs, waitsForPromise */
+
 describe('toggling markdown task', () => {
   let activationPromise, editor, editorView
 


### PR DESCRIPTION
Configure linter for [JavaScript Standard Style](https://standardjs.com) to foster consistency with the [Atom style guide](https://github.com/atom/atom/blob/acdf3b20bd94d58cca74e167108278266b2e3670/CONTRIBUTING.md#javascript-styleguide).

### TODO

- [x] Set up [JavaScript Standard Style](https://standardjs.com) linter
- [x] Resolve existing linter violations
