### PR TITLE
allow more than one whitespace before checkbox

### DIFF
--- a/lib/toggle-markdown-task.js
+++ b/lib/toggle-markdown-task.js
@@ -1,4 +1,4 @@
-const {CompositeDisposable} = require('atom')
+const { CompositeDisposable } = require('atom')
 
 module.exports = ({
   subscriptions: null,
@@ -6,7 +6,7 @@ module.exports = ({
   activate (state) {
     this.subscriptions = new CompositeDisposable()
     this.subscriptions.add(atom.commands.add('atom-text-editor',
-      {'toggle-markdown-task:toggle': () => this.toggle()})
+      { 'toggle-markdown-task:toggle': () => this.toggle() })
     )
   },
 

--- a/lib/toggle-markdown-task.js
+++ b/lib/toggle-markdown-task.js
@@ -1,5 +1,5 @@
 const { CompositeDisposable } = require('atom')
-const taskRegex = new RegExp(/([-*] )(\[[ x]\])/)
+const taskRegex = new RegExp(/([-*] +)(\[[ x]\])/)
 
 module.exports = ({
   subscriptions: null,

--- a/lib/toggle-markdown-task.js
+++ b/lib/toggle-markdown-task.js
@@ -1,4 +1,5 @@
 const { CompositeDisposable } = require('atom')
+const taskRegex = new RegExp(/([-*] )(\[[ x]\])/)
 
 module.exports = ({
   subscriptions: null,
@@ -40,9 +41,7 @@ function toggleSelection (selection) {
 }
 
 function toggleTask (taskText) {
-  const regex = new RegExp(/([-*] )(\[[ x]\])/)
-
-  return taskText.replace(regex, (_, taskPrefix, taskStatus) => {
+  return taskText.replace(taskRegex, (_, taskPrefix, taskStatus) => {
     return (taskStatus === '[ ]') ? `${taskPrefix}[x]` : `${taskPrefix}[ ]`
   })
 }

--- a/spec/toggle-markdown-task-spec.js
+++ b/spec/toggle-markdown-task-spec.js
@@ -140,4 +140,14 @@ describe('toggling markdown task', () => {
       )
     })
   )
+
+  describe('when multiple whitespaces precede checkbox', () =>
+    it('toggles completion of the task', () => {
+      editor.setText('-   [ ] A')
+      editor.setCursorBufferPosition([0, 0])
+
+      toggleMarkdownTask(() => expect(editor.getText()).toBe('-   [x] A')
+      )
+    })
+  )
 })


### PR DESCRIPTION
some markdown linters advocate listing context to be indented with four characters, that is one dash (or similar) and three whitespaces. a todo list would look like this:
```markdown
-   [ ] item1
-   [ ] item2
```
this pr allows `toggle-markdown-task` to handle these cases as well.
